### PR TITLE
fixed error in Schedule/Event and changed character in multiDay

### DIFF
--- a/client/src/components/Schedule/multiDay.jsx
+++ b/client/src/components/Schedule/multiDay.jsx
@@ -1,8 +1,9 @@
 const MultiDayValue = (multiDay) => {
   if (multiDay.multiDay === true) {
     return <div>✔</div>
-  } else
-    return <div>-</div>
+  } else if(multiDay.multiDay === false) {
+    return <div>❌</div>
+  }
 }
 
 export default MultiDayValue

--- a/client/src/pages/Event.jsx
+++ b/client/src/pages/Event.jsx
@@ -94,7 +94,8 @@ const Event = () => {
 
             <tbody>
               {sortedEvents.map((event) => (
-                <tr key={event.id}>
+                <tr key={event._id}>
+                  {/* changed from event.id to get rid of error: 'Each child in a list should have a unique "key" prop.' */}
                   <td>
                     <FormattedDate
                       eventDate={event.eventDate} />

--- a/client/src/pages/Schedule.jsx
+++ b/client/src/pages/Schedule.jsx
@@ -88,7 +88,8 @@ const Schedule = () => {
 
             <tbody>
               {sortedEvents.map((event) => (
-                <tr key={event.id}>
+                <tr key={event._id}>
+                  {/* changed from event.id to get rid of error: 'Each child in a list should have a unique "key" prop.' */}
                   <td>
                     <FormattedDate
                       eventDate={event.eventDate} />


### PR DESCRIPTION
Multi-Day
---------------------------------------
changed character '-' to '❌' when multiDay is false.

Schedule/Event
----------------------------------------
fixed error: 'Each child in a list should have a unique 'key' prop.'
key={event.id} wasn't returning anything.
changed to key={event._id} and error ceased.